### PR TITLE
fix(security): scope TruffleHog hook to staged files only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,13 +63,17 @@ repos:
       - id: trufflehog
         name: TruffleHog Secret Scanner
         description: Detect secrets in your data before committing
+        # Scan staged files only. The git-history mode (--since-commit HEAD) also
+        # traverses fetched remote branches in the local object store, producing
+        # false positives from unmerged branches. Staged-file scanning is the
+        # correct scope for a pre-commit hook; git history scanning belongs in CI.
         entry: >-
           bash -c
           'if ! command -v trufflehog >/dev/null 2>&1; then
             echo "ERROR: trufflehog (Go) not installed. This hook requires the trufflesecurity binary; trufflehog3 has an incompatible CLI and is not a drop-in. Install with: brew install trufflehog (macOS); curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin (Linux/WSL); or see https://github.com/trufflesecurity/trufflehog#installation" >&2;
             exit 1;
           fi;
-          trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail'
+          git diff --cached -z --diff-filter=d --name-only 2>/dev/null | xargs -0 -r trufflehog filesystem --fail --no-update --results=verified,unknown'
         language: system
         pass_filenames: false
         stages: [pre-commit]


### PR DESCRIPTION
## Summary

Replace `trufflehog git file://. --since-commit HEAD` with a staged-files
scan via `git diff --cached | xargs trufflehog filesystem`. The git-history
mode also traverses fetched remote branches in the local object store, which
produces false positives from placeholder credentials in unmerged branches.

See `.claude/rules/pre-commit.md` invariant `PC-HOOK-STAGED-SCOPE` for the
general principle (pre-commit hooks must scope to staged files only;
full-history scanning belongs in CI).

## Why

Resolves observation #4 from `~/.claude/skill-observations/log.md`.
Part of a fleet-wide TruffleHog rollout following the methodology in the
`pre-commit-authoring` skill and the `PC-HOOK-STAGED-SCOPE` invariant in
`.claude/rules/pre-commit.md`.

Generated with [Claude Code](https://claude.ai/code)