### PR TITLE
fix(scorecard): pin python-scorecard.yml to explicit SHA (was @main)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   scorecard:
     name: Scorecard Analysis
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@f05c26a424a708a73fc445a0ebb5b3ce476c1793
     with:
       publish-results: true
       upload-sarif: true


### PR DESCRIPTION
## Summary

- Replaces the floating `@main` ref with `f05c26a424a708a73fc445a0ebb5b3ce476c1793` (current HEAD of `ByronWilliamsCPA/.github`)
- Eliminates the supply-chain risk of silent behavior changes when `.github` main advances
- This SHA also hard-codes `publish_results: false`, fixing the OIDC token `repository` claim bug for reusable workflow callees

Generated with [Claude Code](https://claude.com/claude-code)