### PR TITLE
fix(config): correct $schema URL in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-config.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(git status*)",

--- a/docs/template_feedback.md
+++ b/docs/template_feedback.md
@@ -42,7 +42,22 @@ When working on this project, if you discover any issue that originates from the
 
 <!-- Add your feedback below this line -->
 
-_No feedback items yet. Add issues as they are discovered._
+### Incorrect `$schema` URL in `.claude/settings.json`
+
+- **Priority**: Medium
+- **Category**: Configuration
+- **Discovered**: 2026-05-19
+
+**Issue**: The generated `.claude/settings.json` uses `"$schema": "https://json.schemastore.org/claude-code-config.json"`, but the Claude Code VS Code extension expects `https://json.schemastore.org/claude-code-settings.json`. The wrong URL causes the extension to report "Settings file failed to parse" and silently disables permission rules and other settings from the file.
+
+**Context**: This regression has now been observed twice in this project. It was reintroduced by the repo-compliance standards-alignment sweep on 2026-05-16 (CLAUDE-005 / commit `a02d3e8`), implying the cookiecutter template or the compliance standards manifest still emits the incorrect URL.
+
+**Suggested Fix**: Update the template's `.claude/settings.json` (and any standards-manifest remediation logic that writes this file) to use `claude-code-settings.json` rather than `claude-code-config.json`.
+
+**Affected Files**:
+
+- `{{cookiecutter.project_slug}}/.claude/settings.json` (template)
+- Any compliance/remediation script that emits or rewrites this file (likely in the `claude-docs-auditor` remediation path for CLAUDE-005)
 
 ---
 


### PR DESCRIPTION
## Summary

- Corrects `.claude/settings.json` `$schema` from `claude-code-config.json` to `claude-code-settings.json`. The VS Code extension parses against the latter, and with the wrong URL it reports `"Settings file failed to parse"` and silently disables permission rules and every other configured setting in this file.
- Adds a Medium-priority entry to `docs/template_feedback.md` documenting the regression. This is the **second** time the bug has been observed in this repo (it was reintroduced by the standards-alignment sweep in #18 / `a02d3e8`), so the upstream cookiecutter template (and the CLAUDE-005 remediation logic that rewrites this file) should be corrected.

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` returns clean
- [x] `pre-commit run --files .claude/settings.json docs/template_feedback.md` all green (including no-em-dash, JSON validation, and front-matter validation)
- [ ] After merge: reload the VS Code window and confirm the "Settings file failed to parse" toast no longer appears

Generated with [Claude Code](https://claude.com/claude-code)