### PR TITLE
chore(gitignore): ignore coverage.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/docs/template_feedback.md
+++ b/docs/template_feedback.md
@@ -59,6 +59,22 @@ When working on this project, if you discover any issue that originates from the
 - `{{cookiecutter.project_slug}}/.claude/settings.json` (template)
 - Any compliance/remediation script that emits or rewrites this file (likely in the `claude-docs-auditor` remediation path for CLAUDE-005)
 
+### `coverage.json` not in `.gitignore`
+
+- **Priority**: Low
+- **Category**: Configuration
+- **Discovered**: 2026-05-19
+
+**Issue**: The template's `.gitignore` covers `.coverage`, `.coverage.*`, and `coverage.xml`, but omits `coverage.json`. `coverage.py` writes `coverage.json` when invoked with `--format=json` (used by Codecov's JSON reporter, several IDE integrations, and the `test-coverage` skill), leaving an untracked artifact in the working tree after every coverage run.
+
+**Context**: Discovered during a "final check" repo audit. `coverage.json` was the only untracked file in an otherwise-clean working tree on `main` and had been produced silently by a prior coverage run.
+
+**Suggested Fix**: Add `coverage.json` to the "Unit test / coverage reports" block in `.gitignore` alongside `coverage.xml`.
+
+**Affected Files**:
+
+- `{{cookiecutter.project_slug}}/.gitignore`
+
 ---
 
 ## Submitting Feedback


### PR DESCRIPTION
## Summary

- Add `coverage.json` to `.gitignore` alongside the existing `coverage.xml` / `.coverage` entries
- Log the gap in `docs/template_feedback.md` so the cookiecutter template ships the entry upstream

`coverage.py` writes `coverage.json` when invoked with `--format=json` (used by Codecov's JSON reporter, several IDE integrations, and the `test-coverage` skill). The file was the lone untracked artifact in an otherwise-clean working tree on `main`, surfaced during a final-state repo audit.

## Test plan

- [x] `pre-commit run --files .gitignore docs/template_feedback.md` -- passed
- [x] Verified `coverage.json` is now matched by the ignore pattern (`git check-ignore coverage.json`)

Generated with [Claude Code](https://claude.com/claude-code)