### PR TITLE
fix(deps): bump planning scaffold pins to silence 8 CVEs

### DIFF
--- a/docs/planning/backend/requirements.txt
+++ b/docs/planning/backend/requirements.txt
@@ -16,7 +16,8 @@ httpx==0.26.0
 
 # Web scraping
 beautifulsoup4==4.12.3
-lxml==5.1.0
+# lxml: bumped from 5.1.0 to silence iterparse/ETCompatXMLParser XXE CVE
+lxml==6.1.0
 
 # Data processing
 pandas==2.2.0
@@ -25,11 +26,15 @@ pandas==2.2.0
 asyncpg==0.29.0
 
 # CORS
-python-multipart==0.0.9
+# python-multipart: bumped from 0.0.9 to silence DoS / arbitrary-write CVE chain
+# (covers patched versions 0.0.18, 0.0.22, 0.0.26, 0.0.27)
+python-multipart==0.0.27
 
 # Testing
-pytest==8.0.0
+# pytest: bumped from 8.0.0 to silence tmpdir handling CVE (fixed in 9.0.3)
+pytest==9.0.3
 pytest-asyncio==0.23.4
 
 # Utilities
-python-dotenv==1.0.1
+# python-dotenv: bumped from 1.0.1 to silence set_key symlink-following CVE
+python-dotenv==1.2.2

--- a/docs/planning/frontend/package.json
+++ b/docs/planning/frontend/package.json
@@ -23,6 +23,6 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.1.0"
+    "vite": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Summary

Bump the pinned versions in two planning prototypes to silence 8 GitHub vulnerability alerts (4 HIGH, 4 MEDIUM):

| Package | Before | After | Severity | Advisory |
|---|---|---|---|---|
| `python-multipart` | `0.0.9` | `0.0.27` | HIGH x3, MED x1 | DoS via boundary deformation; arbitrary file write; DoS via unbounded headers; DoS via large preamble |
| `lxml` | `5.1.0` | `6.1.0` | HIGH | XXE to local files via default `iterparse()` / `ETCompatXMLParser()` configuration |
| `python-dotenv` | `1.0.1` | `1.2.2` | MED | `set_key` symlink-following allows arbitrary file overwrite |
| `pytest` | `8.0.0` | `9.0.3` | MED | Vulnerable `tmpdir` handling |
| `vite` | `^5.1.0` | `^6.4.2` | MED | Path traversal in optimized deps `.map` handling |

## Why these are in scaffolds, not real deps

`docs/planning/backend/` and `docs/planning/frontend/` are deliberate **planning prototypes** that Roadmap Phase 3 migrates into `src/`. They are not installed by any runtime path; the project's real dependencies live in `pyproject.toml` with `>=` constraints that uv resolves to current safe versions. SECURITY-FINDINGS.md (§1.2, §2.2, §3.2, §4.2) treats these prototypes as reference material to be hardened before migration, not as production code.

GitHub's native vulnerability scanning, however, scans every manifest in the repo regardless of whether it is installed, and surfaces alerts against the planning pins. The fix is to move each pin to the first patched release per the advisory while retaining the `==` semantic ("verified at planning time").

## Interaction with Renovate

This repo uses **Renovate, not Dependabot**. Renovate's `enabledManagers` is set to `["poetry", "github-actions"]`, so it does not see `pip` (`requirements.txt`) or `npm` (`package.json`) manifests under `docs/planning/`. No update flow is disturbed by this PR.

## Test plan

- [x] `pre-commit run` on both modified files -- passed (JSON validation included)
- [x] Verified pinned versions match the `first_patched_version` field returned by `gh api repos/.../dependabot/alerts` for each alert
- [x] No runtime path imports these scaffolds (`grep -rln "docs/planning/(backend|frontend)" --include="*.py"` returns only `SECURITY-FINDINGS.md`)

## Follow-up

After merge, the 8 alerts on https://github.com/ByronWilliamsCPA/fragrance-rater/security/dependabot should auto-resolve. If any persist (e.g., transitive scans), they can be dismissed in the UI with reason "no-bandwidth" since the scaffolds are inert.

Generated with [Claude Code](https://claude.com/claude-code)