### PR TITLE
chore(renovate): switch to pep621 manager (uv-managed projects)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `# noqa: PLC0415`, add `ClassVar` annotations to `WorkerSettings` lists,
   rename unused `body` parameter to `_body`, and add types to the
   `before_send` Sentry callback in `middleware/correlation.py`.
+- Renovate: switched `enabledManagers` and `packageRules.matchManagers` from
+  `poetry` to `pep621` so Renovate correctly discovers Python dependencies
+  declared under `[project.dependencies]` in `pyproject.toml`; updated
+  `matchDepTypes` to `project.dependencies` and `dependency-groups` /
+  `tool.uv.dev-dependencies` to match pep621 manager depType names; removed
+  the now-unused `poetry` manager config block and `poetryMassage` post-update
+  option.
 
 ### Documentation
 

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -163,12 +163,6 @@
   "python": {
     "enabled": true
   },
-  "poetry": {
-    "enabled": true,
-    "fileMatch": [
-      "(^|/)pyproject\\.toml$"
-    ]
-  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -203,9 +197,6 @@
   },
   "osvVulnerabilityAlerts": true,
   "transitiveRemediation": true,
-  "postUpdateOptions": [
-    "poetryMassage"
-  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -218,7 +209,7 @@
     }
   ],
   "enabledManagers": [
-    "poetry",
+    "uv",
     "github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -209,7 +209,7 @@
     }
   ],
   "enabledManagers": [
-    "uv",
+    "pep621",
     "github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "dependencies"
+        "project.dependencies"
       ],
       "groupName": "Python dependencies",
       "automerge": false,
@@ -43,7 +43,8 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "devDependencies"
+        "dependency-groups",
+        "tool.uv.dev-dependencies"
       ],
       "groupName": "Python dev dependencies",
       "automerge": false,


### PR DESCRIPTION
## Summary

This repo manages dependencies with uv (\`uv.lock\` present), but \`renovate.json\` declared:

\`\`\`json
\"enabledManagers\": [\"poetry\", \"github-actions\"]
\`\`\`

Renovate's \`enabledManagers\` is replace-not-merge, so the global config does not fill in \`pep621\`. The \`poetry\` manager tries to parse \`pyproject.toml\`'s \`[tool.poetry.dependencies]\` table, but uv projects declare deps under \`[project.dependencies]\`. Result: Renovate silently parses zero Python deps and produces no PRs.

## Changes

- \`enabledManagers\`: \`poetry\` -> \`pep621\`
- \`packageRules[*].matchManagers\`: \`poetry\` -> \`pep621\`
- \`packageRules[0].matchDepTypes\`: \`dependencies\` -> \`project.dependencies\`
- \`packageRules[1].matchDepTypes\`: \`devDependencies\` -> \`["dependency-groups", "tool.uv.dev-dependencies"]\`
- Removed top-level \`"poetry": { ... }\` config block
- Removed \`"poetryMassage"\` from \`postUpdateOptions\`

## Test plan

- [ ] Renovate dashboard issue regenerates with Python dependency PRs after merge
- [ ] No regression in GitHub Actions dependency PRs