### PR TITLE
fix(slsa): download pre-built artifacts instead of rebuilding

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -14,16 +14,19 @@
 name: SLSA Provenance
 
 on:
-  # Trigger after successful release
-  workflow_run:
-    workflows: ["Semantic Release"]
-    types: [completed]
-    branches: [main, master]
+  # Trigger when a GitHub Release is published. The Release and its
+  # .whl/.tar.gz assets are created atomically by the Semantic Release
+  # workflow before this event fires, so github.event.release.tag_name
+  # deterministically identifies the exact artifacts to attest. This avoids
+  # the "latest release" race a workflow_run trigger would introduce when
+  # multiple releases land close together or an old run is re-run.
+  release:
+    types: [published]
   # Manual trigger for re-generating provenance
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version (tag without leading v) to generate provenance for (e.g., 0.1.0)'
+        description: 'Release version or tag, with or without leading v (e.g., 0.1.0 or v0.1.0)'
         required: true
         type: string
 
@@ -39,7 +42,7 @@ jobs:
   prepare:
     name: Prepare Subjects
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
     permissions:
       contents: read
     outputs:
@@ -55,6 +58,7 @@ jobs:
         id: tag
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
@@ -76,9 +80,17 @@ jobs:
               exit 1
             fi
           else
-            TAG=$(gh release view --json tagName --jq '.tagName')
+            # release: published event. Use the tag from the event payload,
+            # which deterministically identifies the just-published release
+            # rather than whichever release happens to be newest at run time.
+            TAG="${RELEASE_TAG:-}"
             if [ -z "$TAG" ]; then
-              echo "::error::Could not determine latest release tag"
+              echo "::error::release event did not provide a tag name"
+              exit 1
+            fi
+            # Validate against the same charset as the manual input path.
+            if ! [[ "$TAG" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+              echo "::error::Invalid release tag: must match ^[A-Za-z0-9._+-]+$"
               exit 1
             fi
           fi
@@ -107,7 +119,17 @@ jobs:
         working-directory: dist
         run: |
           set -euo pipefail
-          HASHES=$(sha256sum ./*.whl ./*.tar.gz | base64 -w0)
+          # nullglob so an absent artifact type expands to nothing rather than
+          # passing a literal unmatched glob to sha256sum (which would fail
+          # under `set -e`). Bare filenames (no ./ prefix) keep the SLSA
+          # subject names aligned with the published artifact names.
+          shopt -s nullglob
+          files=(*.whl *.tar.gz)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No .whl or .tar.gz artifacts found in dist/"
+            exit 1
+          fi
+          HASHES=$(sha256sum "${files[@]}" | base64 -w0)
           echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
 
   # ==========================================================================

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,10 +1,16 @@
 # SLSA Provenance Generation for Fragrance Rater
 # Generates SLSA Level 3 provenance attestations for published packages.
 #
-# This workflow builds the package, generates hashes, and calls the org-level
-# SLSA provenance workflow to create cryptographic attestations.
+# Pattern: Download pre-built artifacts from the GitHub Release that the
+# Semantic Release workflow just created, compute base64 SHA256 subjects
+# from those downloaded files, then call the official SLSA generator
+# reusable workflow directly. Locally rebuilding with `uv build` would
+# produce non-deterministic artifacts whose hashes diverge from what was
+# actually published, defeating the purpose of supply chain provenance.
 #
 # Reference: https://slsa.dev/
+# See also: ByronWilliamsCPA/.github/.github/workflows/python-slsa.yml
+# (a template, not callable; copy its provenance job per its instructions)
 name: SLSA Provenance
 
 on:
@@ -17,99 +23,109 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to generate provenance for (e.g., 0.1.0)'
+        description: 'Version (tag without leading v) to generate provenance for (e.g., 0.1.0)'
         required: true
         type: string
 
-permissions:
-  contents: write
-  id-token: write
-  actions: read
-  attestations: write
+permissions: {}
 
 jobs:
   # ==========================================================================
-  # Build and Generate Hashes
+  # Resolve Release Tag and Download Pre-Built Artifacts
   # ==========================================================================
-  build:
-    name: Build Package
+  # NOTE: This job DOES NOT rebuild the package. SLSA provenance must attest
+  # to the exact bytes that were published; rebuilding would yield different
+  # sha256 (timestamps, build paths, tool versions) and break the chain.
+  prepare:
+    name: Prepare Subjects
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
-      version: ${{ steps.version.outputs.version }}
-
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install UV
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-
-      - name: Determine version
-        id: version
+      - name: Resolve release tag
+        id: tag
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION:-}" ]; then
             # Validate version string to allow only semver-like characters
             if ! [[ "$INPUT_VERSION" =~ ^[A-Za-z0-9._+-]+$ ]]; then
               echo "::error::Invalid version input: must match ^[A-Za-z0-9._+-]+$"
               exit 1
             fi
-            VERSION="$INPUT_VERSION"
+            # Accept either "0.1.0" or "v0.1.0"; normalize to the tag GH used.
+            CAND="$INPUT_VERSION"
+            if gh release view "$CAND" >/dev/null 2>&1; then
+              TAG="$CAND"
+            elif gh release view "v$CAND" >/dev/null 2>&1; then
+              TAG="v$CAND"
+            else
+              echo "::error::No GitHub Release found for '$CAND' or 'v$CAND'"
+              exit 1
+            fi
           else
-            VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+            TAG=$(gh release view --json tagName --jq '.tagName')
+            if [ -z "$TAG" ]; then
+              echo "::error::Could not determine latest release tag"
+              exit 1
+            fi
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
 
-      - name: Build package
-        run: uv build
-
-      - name: Generate SHA256 hashes
-        id: hashes
+      - name: Download release artifacts (pre-built)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          cd dist
-          HASHES=$(sha256sum * | base64 -w0)
-          echo "hashes=$HASHES" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          mkdir -p dist
+          # Download only the Python distribution artifacts published by
+          # the Semantic Release workflow. We intentionally do NOT rebuild.
+          gh release download "$TAG" \
+            --pattern '*.whl' \
+            --pattern '*.tar.gz' \
+            --dir dist
+          echo "Downloaded artifacts:"
+          ls -lh dist/
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist-${{ steps.version.outputs.version }}
-          path: dist/
-          retention-days: 90
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: 'dist/*'
+      - name: Generate SHA256 subjects (base64)
+        id: hashes
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          HASHES=$(sha256sum ./*.whl ./*.tar.gz | base64 -w0)
+          echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
 
   # ==========================================================================
-  # SLSA Level 3 Provenance (Org-Level Reusable Workflow)
+  # SLSA Level 3 Provenance
   # ==========================================================================
-  slsa:
-    name: SLSA Level 3
-    needs: [build]
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-slsa.yml@1b2d33c47cc11a96b9757b49f41873c54e75f57c  # main
-    with:
-      base64-subjects: ${{ needs.build.outputs.hashes }}
-      upload-assets: true
+  # The org-level python-slsa.yml is a template (workflow_dispatch only),
+  # not a callable reusable workflow. Per its own instructions we call the
+  # official SLSA generator directly here.
+  provenance:
+    name: Generate SLSA Provenance
+    needs: [prepare]
     permissions:
+      actions: read
       id-token: write
       contents: write
-      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
+    with:
+      base64-subjects: ${{ needs.prepare.outputs.hashes }}
+      upload-assets: true
+      upload-tag-name: ${{ needs.prepare.outputs.tag }}
+      provenance-name: multiple.intoto.jsonl


### PR DESCRIPTION
## Problem

The previous `slsa-provenance.yml` had two defects that compounded into a hard failure on every run:

1. **Wrong source for hashes.** The `build` job ran `uv build` to recreate `dist/` locally, then hashed the rebuilt artifacts. Per the canonical guidance in `feedback_slsa_provenance_pattern.md`:

   > SLSA provenance must attest to the exact bytes that were actually published. Locally rebuilding produces non-deterministic outputs (timestamps, build paths, tool versions) whose sha256 diverges from what PyPI / the GitHub Release received, defeating the purpose of supply-chain provenance.

2. **Calling a template as a reusable workflow.** The `slsa` job called `ByronWilliamsCPA/.github/.github/workflows/python-slsa.yml`, but that file is a template (`workflow_dispatch:` only, no `on.workflow_call` trigger). Recent runs failed with:

   > workflow is not reusable as it is missing a `on.workflow_call` trigger

   The org template's own header documents this and instructs callers to copy the `provenance` job directly into their workflow.

## Fix

- Replace the `build` job with a `prepare` job that resolves the release tag (from `workflow_run` context or the manual `version` input) and downloads the published `.whl` / `.tar.gz` via `gh release download`. No rebuild.
- Compute base64 sha256 subjects from those downloaded files.
- Call `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml` directly (pinned to v2.1.0 SHA `f7dd8c5...`), matching the pattern the org template's own header documents.
- Tighten `permissions` to least-privilege per job and pass all derived strings through `env:` (workflow-injection hardening).

## Why GitHub Release, not PyPI

`fragrance-rater` publishes to both PyPI and GitHub Releases via the canonical `python-release.yml`. The Release is created by the same Semantic Release run that triggers this workflow, so it is the synchronous source of truth available to `workflow_run`. PyPI publishing happens on the `release: published` event in `publish-pypi.yml`, which races this workflow. We hash the Release assets, which the publish job uploads to PyPI byte-for-byte.

## Verification

- `actionlint .github/workflows/slsa-provenance.yml` clean
- `pre-commit run --files .github/workflows/slsa-provenance.yml` all hooks pass (including PC-011 em-dash check)
- Commit signed (ED25519)

Reference: `~/.claude/projects/-home-byron-dev--claude/memory/feedback_slsa_provenance_pattern.md`
---

## Update: review fixes (commit 01be383)

Applied during `/pr-review` + `/pr-fix`:

- **Trigger changed to `release: [published]`** (was `workflow_run` on Semantic Release). The tag is now resolved deterministically from `github.event.release.tag_name` rather than the *latest* release. The prior approach could attest the wrong release's artifacts if two releases landed close together or an old run was re-run (raised by Copilot). The PyPI-publish race noted in "Why GitHub Release, not PyPI" above does not affect hashing of the GitHub *Release* assets, which are created atomically before the event fires, so that rationale no longer requires `workflow_run`.
- **Hashing step hardened**: `shopt -s nullglob` + non-empty guard so a wheel-only or sdist-only release no longer crashes `sha256sum` under `set -euo pipefail`; bare filenames also drop the stray `./` subject-name prefix.
- **Manual input description** clarified to match the script (accepts `0.1.0` or `v0.1.0`).
- **Branch rebased on `main`**: the 5 prior CI failures were inherited from the stale base, not introduced by this diff, and are now green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored release workflow to enhance artifact integrity verification and provenance attestation. The workflow now directly processes published release assets and supports flexible version input handling, improving reliability and efficiency of the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/fragrance-rater/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->