### PR TITLE
fix(release): switch to workflow_run trigger, disable PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,9 +3,11 @@
 # shared PyPI publishing workflow with OIDC trusted publishing.
 name: Publish to PyPI
 
+# Private repo: PyPI publishing is manual-only. The `release: published`
+# auto-trigger is intentionally omitted so that GitHub Releases created by
+# release.yml do not publish to PyPI. Run this workflow via workflow_dispatch
+# to publish deliberately.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       test-pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
 ---
-# Release Workflow
-# Handles automated releases with semantic versioning or
-# manual tag-based releases.
+# Release Workflow - Calls Org-Level Reusable Workflow
+# Handles automated releases with semantic versioning.
 #
 # Features:
 #   - Pre-release testing
-#   - Semantic versioning (if enabled) or manual tag-based releases
-#   - PyPI publishing with OIDC trusted publishing
+#   - Semantic versioning with conventional commits
 #   - GitHub Release creation
 name: Semantic Release
 
 "on":
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches:
       - main
       - master
@@ -30,27 +30,33 @@ name: Semantic Release
 
 # Prevent concurrent releases
 concurrency:
-  group: "release-${{ github.ref }}"
+  group: "release-${{ github.event.workflow_run.head_branch || github.ref_name }}"
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
-  attestations: write
+  contents: read
 
-# Uses org-level reusable workflow
 jobs:
   release:
     name: Release Pipeline
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     uses: ByronWilliamsCPA/.github/.github/workflows/python-release.yml@e070932adbacf11d72cf6fab5962c9398621104c  # main
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+      attestations: write
     with:
       python-version: '3.12'
       coverage-threshold: 80
       source-directory: 'src'
       semantic-release: true
       force-release: "${{ github.event.inputs.force_release || '' }}"
-      publish-to-pypi: true
+      publish-to-pypi: false
       pypi-package-name: 'fragrance-rater'
-      run-tests: true
+      run-tests: false
+      skip-tests-reason: 'Tests run in upstream CI pipeline before this workflow fires'
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
       force-release: "${{ github.event.inputs.force_release || '' }}"
       publish-to-pypi: false
       pypi-package-name: 'fragrance-rater'
-      run-tests: false
-      skip-tests-reason: 'Tests run in upstream CI pipeline before this workflow fires'
+      # workflow_run fires only after CI passed, so tests are already
+      # validated; a manual workflow_dispatch has no such upstream gate, so
+      # run tests in the release pipeline to avoid releasing unvalidated code.
+      run-tests: ${{ github.event_name == 'workflow_dispatch' }}
+      skip-tests-reason: 'Tests already validated by upstream CI before workflow_run fires'
     secrets: inherit


### PR DESCRIPTION
## Summary

- Change release trigger from `push: branches` to `workflow_run: ["CI"]` so releases are gated behind CI success
- Update concurrency group key to `head_branch` for `workflow_run` events
- Move permissions to job level; workflow-level drops to `contents: read`
- Set `publish-to-pypi: false` (private repo — no PyPI publishing)
- Set `run-tests: false` + `skip-tests-reason` (CI already validated tests upstream)
- Add `secrets: inherit` for reusable workflow token passthrough

## Context

Part of fleet-wide replication of PSR v10.5.3 bug mitigations. The core fixes (vcs_release, commit:false, HEAD attachment) live in the org-level reusable workflow (ByronWilliamsCPA/.github PR #184). This PR updates the caller to use the CI-gated trigger pattern.

## Test plan

- [ ] Confirm CI workflow passes on this PR
- [ ] After merging ByronWilliamsCPA/.github PR #184, verify a merge to main triggers the release workflow via `workflow_run`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger only after CI passes successfully, while preserving manual dispatch capability.
  * Disabled PyPI publishing in release workflow.
  * Made test execution conditional—tests run only on manual workflow dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/fragrance-rater/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->