### PR TITLE
fix(ci): pass no-build: false to SBOM reusable workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -44,6 +44,11 @@ jobs:
       severity-threshold: 'CRITICAL,HIGH'
       artifact-retention-days: 90
       fail-on-forbidden-licenses: false
+      # The reusable workflow defaults `no-build: true`, which fails with
+      # "Distribution can't be installed because it is marked as --no-build
+      # but has no binary distribution" for projects installed as
+      # `editable+.`. Override to false so uv can build the package.
+      no-build: false
     secrets:
       INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
       INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: override `no-build: false` for callers of the reusable `python-ci.yml`
   and `python-docs.yml` workflows so editable package install succeeds (`ci.yml`,
   `pr-validation.yml`, `docs.yml`).
+- CI: extend the same `no-build: false` override to `sbom.yml` (caller of
+  `python-sbom.yml`) so editable package install succeeds during SBOM generation;
+  resolves three consecutive "Generate SBOMs" failures (closes #36).
 - CI: remove `.github/workflows/sonarcloud.yml`; the dual CI scanner + project-level
   Automatic Analysis combination caused every run to error. Automatic Analysis
   continues unchanged at the SonarCloud project level (covers bugs,


### PR DESCRIPTION
## Summary

- Adds `no-build: false` to the SBOM caller workflow so `uv` can build
  the editable hatchling package during SBOM generation.
- Mirrors the identical override already present in `ci.yml` (added for
  the same reason).
- The reusable workflow's default of `no-build: true` has caused three
  consecutive failures since 2026-05-19 (run IDs: 26597103339,
  26393290269, 26103904654).

## Test plan

- [ ] "SBOM & Security / Generate SBOMs" check passes on this PR
- [ ] No other workflow checks regress

Closes #36

Generated with [Claude Code](https://claude.com/claude-code)