### PR TITLE
fix(slsa): add concurrency guard and align provenance filename docs

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -30,6 +30,14 @@ on:
         required: true
         type: string
 
+# Serialize runs that target the same tag (e.g. a release event plus a manual
+# retry) so they cannot contend while uploading provenance assets. Never cancel
+# an in-flight attestation: a half-uploaded provenance file is worse than a
+# slightly delayed one.
+concurrency:
+  group: slsa-provenance-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/docs/OPENSSF_COMPLIANCE.md
+++ b/docs/OPENSSF_COMPLIANCE.md
@@ -81,11 +81,11 @@ cosign verify-blob \
 
 ```bash
 # Download provenance file
-wget https://github.com/ByronWilliamsCPA/fragrance_rater/releases/download/v1.0.0/attestation.intoto.jsonl
+wget https://github.com/ByronWilliamsCPA/fragrance_rater/releases/download/v1.0.0/multiple.intoto.jsonl
 
 # Verify with slsa-verifier
 slsa-verifier verify-artifact package.whl \
-  --provenance-path attestation.intoto.jsonl \
+  --provenance-path multiple.intoto.jsonl \
   --source-uri github.com/ByronWilliamsCPA/fragrance_rater
 ```
 


### PR DESCRIPTION
## Problem

Follow-up to #31, which auto-merged the moment it went green, before two CodeRabbit findings raised during the `/pr-review` + `/pr-fix` pass could be addressed. Both are now live in `main`:

1. **[Major] Provenance filename vs docs mismatch.** The workflow publishes `multiple.intoto.jsonl` (via `provenance-name`), but `docs/OPENSSF_COMPLIANCE.md` instructs consumers to download and verify `attestation.intoto.jsonl`. Anyone copy-pasting the documented `slsa-verifier` command hits the wrong filename.
2. **[Nitpick] No workflow-level concurrency.** `zizmor` flags `concurrency-limits`: a release event plus a manual retry for the same tag can overlap while uploading provenance assets.

## Fix

- Align the doc with the workflow: `docs/OPENSSF_COMPLIANCE.md` now references `multiple.intoto.jsonl` (kept the workflow name, since it is the generator's conventional multi-subject name).
- Add a top-level `concurrency` block keyed on `github.event.release.tag_name || github.event.inputs.version || github.ref` with `cancel-in-progress: false`, so same-tag runs serialize and an in-flight attestation is never cancelled.

## Verification

- `actionlint` clean
- Pre-commit hooks pass (including PC-011 em-dash check)
- Commit signed (ED25519)

Refs #31.

🤖 Generated with [Claude Code](https://claude.ai/code)