### PR TITLE
chore: replace darglint with pydoclint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 ci:
   autoupdate_schedule: monthly
   autofix_prs: true
-  skip: [validate-front-matter, qlty-check, qlty-full, trufflehog, darglint, bandit, bandit-full]  # Skip local-only hooks
+  skip: [validate-front-matter, qlty-check, qlty-full, trufflehog, bandit, bandit-full]  # Skip local-only hooks
 
 repos:
   # ============================================================================
@@ -244,17 +244,16 @@ repos:
   # ============================================================================
   # Docstring Argument Validation
   # ============================================================================
-  # Darglint validates that docstring arguments match function signatures
-  # Configuration in pyproject.toml [tool.darglint]
-  - repo: local
+  # Pydoclint validates that docstring arguments match function signatures
+  # Configuration in pyproject.toml [tool.pydoclint]
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 88d83c94156c5e51a09938e77019f2c58e92ab58  # 0.8.4  # pragma: allowlist secret
     hooks:
-      - id: darglint
-        name: Darglint docstring validation
-        entry: uv run darglint
-        language: system
+      - id: pydoclint
+        args: ["--config=pyproject.toml"]
         types: [python]
         stages: [pre-commit]
-        exclude: ^(tests|scripts|benchmarks|tools)/
+        exclude: ^(tests|scripts|benchmarks|tools|docs)/
 
 # Exclude patterns
 exclude: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "bandit>=1.7.0",
     "vulture>=2.11",  # Dead code detection
     "pip-audit>=2.7.0",  # Python vulnerability scanning
-    "darglint>=1.8.1",  # Docstring argument validation
+    "pydoclint>=0.8.4",  # Docstring argument validation
 
     # Pre-commit
     "pre-commit>=3.3.0",
@@ -580,26 +580,18 @@ ignore-init-method = true
 ignore-init-module = true
 color = true
 
-# Darglint Configuration (Docstring Argument Validation)
+# Pydoclint Configuration (Docstring Argument Validation)
 # Validates that docstring arguments match function signatures
-# Reference: https://github.com/terrencepreilly/darglint
-[tool.darglint]
-# Google-style docstrings (matches ruff pydocstyle convention)
-docstring_style = "google"
-# Strictness levels: short, long, full
-# - short: Only documented items must exist in signature
-# - long: All parameters must be documented (recommended)
-# - full: Types in docstring must match annotations
-strictness = "long"
-# Ignore missing parameter documentation in these cases
-ignore = [
-    "DAR101",  # Missing parameter(s) in Docstring (initially lenient)
-    "DAR201",  # Missing "Returns" in Docstring (handled by pydocstyle)
-    "DAR301",  # Missing "Yields" in Docstring
-    "DAR401",  # Missing exception(s) in Raises section
-]
-# Ignore in these directories
-ignore_regex = "^(tests|scripts|benchmarks|tools)/.*$"
+# Reference: https://github.com/jsh9/pydoclint
+[tool.pydoclint]
+style = "google"
+exclude = '\.git|tests/|scripts/|benchmarks/|tools/|noxfile\.py|\.claude/|docs/'
+arg-type-hints-in-docstring = true
+arg-type-hints-in-signature = true
+skip-checking-raises = false
+require-return-section-when-returning-nothing = false
+require-return-section-when-returning-values = false
+require-yield-section-when-yielding-values = false
 
 # Mutation Testing Configuration (mutmut)
 [tool.mutmut]

--- a/src/fragrance_rater/api/fragrances.py
+++ b/src/fragrance_rater/api/fragrances.py
@@ -21,10 +21,10 @@ class Fragrance(BaseModel):
     """A fragrance catalog entry.
 
     Attributes:
-        id: Stable integer identifier.
-        name: Fragrance name.
-        brand: Fragrance house / brand.
-        notes: Accord / top / heart / base notes.
+        id (int): Stable integer identifier.
+        name (str): Fragrance name.
+        brand (str): Fragrance house / brand.
+        notes (list[str]): Accord / top / heart / base notes.
     """
 
     id: int = Field(..., ge=1, description="Stable integer identifier.")
@@ -79,7 +79,7 @@ def list_fragrances() -> FragranceListResponse:
     by the data pipeline (ADR-002).
 
     Returns:
-        The full catalog with its item count.
+        FragranceListResponse: The full catalog with its item count.
     """
     return FragranceListResponse(items=_SAMPLE_CATALOG, total=len(_SAMPLE_CATALOG))
 
@@ -103,10 +103,10 @@ def get_fragrance(fragrance_id: int) -> Fragrance:
     for a fragrance.
 
     Args:
-        fragrance_id: Integer primary key of the catalog entry.
+        fragrance_id (int): Integer primary key of the catalog entry.
 
     Returns:
-        The matching fragrance record.
+        Fragrance: The matching fragrance record.
 
     Raises:
         HTTPException: 404 when no entry has the requested id.

--- a/src/fragrance_rater/api/health.py
+++ b/src/fragrance_rater/api/health.py
@@ -69,7 +69,7 @@ async def liveness() -> HealthStatus:
     This should be a simple, fast check that doesn't depend on external services.
 
     Returns:
-        HealthStatus with overall status "ok" and current uptime in seconds.
+        HealthStatus: Status "ok" and current uptime in seconds.
     """
     return HealthStatus(
         status="ok",
@@ -81,7 +81,7 @@ async def check_database() -> ReadinessCheck:
     """Check database connectivity.
 
     Returns:
-        ReadinessCheck with database status and latency
+        ReadinessCheck: Database status and latency.
     """
     start = time.time()
     try:
@@ -117,7 +117,7 @@ async def check_cache() -> ReadinessCheck:
     """Check Redis/cache connectivity.
 
     Returns:
-        ReadinessCheck with cache status and latency
+        ReadinessCheck: Cache status and latency.
     """
     start = time.time()
     try:
@@ -147,7 +147,7 @@ async def check_external_service() -> ReadinessCheck:
     """Check external API/service connectivity.
 
     Returns:
-        ReadinessCheck with external service status
+        ReadinessCheck: External service status.
     """
     start = time.time()
     try:
@@ -197,7 +197,7 @@ async def readiness() -> ReadinessStatus:
     If this fails, Kubernetes will stop sending traffic to this pod.
 
     Returns:
-        ReadinessStatus with per-dependency check results and overall uptime.
+        ReadinessStatus: Per-dependency check results and overall uptime.
 
     Raises:
         HTTPException: 503 when any critical dependency reports unhealthy.
@@ -251,7 +251,7 @@ async def startup() -> HealthStatus:
     Returns HTTP 200 once the application has fully started.
 
     Returns:
-        HealthStatus with status "started" once initialization is complete.
+        HealthStatus: Status "started" once initialization is complete.
     """
     # Add any startup checks here (e.g., database migrations completed)
     # For most applications, being alive means startup is complete
@@ -277,7 +277,7 @@ async def health() -> HealthStatus:
     that expect a /health endpoint.
 
     Returns:
-        HealthStatus snapshot identical to the liveness probe response.
+        HealthStatus: Snapshot identical to the liveness probe response.
     """
     return await liveness()
 

--- a/src/fragrance_rater/api/ratings.py
+++ b/src/fragrance_rater/api/ratings.py
@@ -26,10 +26,10 @@ class RatingRequest(BaseModel):
     """Request body for ``POST /ratings``.
 
     Attributes:
-        name: Fragrance name (required).
-        brand: Fragrance house or brand. Improves rating accuracy.
-        description: Free-text description of the scent profile.
-        notes: Optional list of accord/top/heart/base notes.
+        name (str): Fragrance name (required).
+        brand (str | None): Fragrance house or brand. Improves rating accuracy.
+        description (str): Free-text description of the scent profile.
+        notes (list[FragranceNote] | None): Optional list of accord/top/heart/base notes.
     """
 
     name: str = Field(
@@ -73,11 +73,11 @@ class RatingResponse(BaseModel):
     """Response body returned by ``POST /ratings``.
 
     Attributes:
-        score: Integer rating, 1 (poor) to 10 (excellent).
-        reasoning: Human-readable explanation written by the LLM.
-        model: Identifier of the LLM that produced the rating.
-        notes: Echo of accord notes used by the model.
-        latency_warning: Reminder that LLM latency is variable.
+        score (int): Integer rating, 1 (poor) to 10 (excellent).
+        reasoning (str): Human-readable explanation written by the LLM.
+        model (str): Identifier of the LLM that produced the rating.
+        notes (list[str]): Echo of accord notes used by the model.
+        latency_warning (str): Reminder that LLM latency is variable.
     """
 
     score: int = Field(
@@ -131,11 +131,11 @@ def create_rating(
     paths on this call.
 
     Args:
-        payload: Validated rating request body.
-        client: LLM rating client injected via FastAPI dependency.
+        payload (RatingRequest): Validated rating request body.
+        client (LLMRatingClient): LLM rating client injected via FastAPI dependency.
 
     Returns:
-        The LLM-authored rating, model identifier, and latency note.
+        RatingResponse: The LLM-authored rating, model identifier, and latency note.
 
     Raises:
         HTTPException: 503 when the upstream LLM client is unavailable

--- a/src/fragrance_rater/core/config.py
+++ b/src/fragrance_rater/core/config.py
@@ -10,16 +10,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """
-    Configuration settings for the application, loaded from environment variables.
+    """Configuration settings for the application, loaded from environment variables.
 
     Attributes:
-        log_level: The logging level for the application.
-        json_logs: Flag to enable or disable JSON formatted logs.
-        include_timestamp: Flag to include timestamps in logs.
+        model_config (SettingsConfigDict): Pydantic-settings model configuration
+            (env prefix, case sensitivity, extra field policy).
+        log_level (Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']): The
+            logging level for the application.
+        json_logs (bool): Flag to enable or disable JSON formatted logs.
+        include_timestamp (bool): Flag to include timestamps in logs.
     """
 
-    model_config = SettingsConfigDict(
+    model_config: SettingsConfigDict = SettingsConfigDict(
         env_prefix="fragrance_rater_",
         case_sensitive=False,
         extra="ignore",

--- a/src/fragrance_rater/core/exceptions.py
+++ b/src/fragrance_rater/core/exceptions.py
@@ -43,10 +43,10 @@ class ProjectBaseError(Exception):
     All custom exceptions in the project should inherit from this class
     to enable unified error handling and logging.
 
-    Attributes:
-        message: Human-readable error message.
-        details: Additional context about the error (optional).
-        error_code: Machine-readable error code for API responses (optional).
+    Args:
+        message (str): Human-readable error description.
+        details (dict[str, Any] | None): Additional context as key-value pairs.
+        error_code (str | None): Machine-readable error code.
 
     Example:
         >>> raise ProjectBaseError("Something went wrong", error_code="ERR001")
@@ -59,13 +59,6 @@ class ProjectBaseError(Exception):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize the exception.
-
-        Args:
-            message: Human-readable error description.
-            details: Additional context as key-value pairs.
-            error_code: Machine-readable error code.
-        """
         super().__init__(message)
         self.message = message
         self.details = details or {}
@@ -75,7 +68,7 @@ class ProjectBaseError(Exception):
         """Convert exception to dictionary for API responses.
 
         Returns:
-            Dictionary with error details suitable for JSON serialization.
+            dict[str, Any]: Error details suitable for JSON serialization.
         """
         result: dict[str, Any] = {
             "error": self.__class__.__name__,
@@ -108,6 +101,13 @@ class ValidationError(ProjectBaseError):
     Raised when user input or data fails validation rules.
     Includes field-level error details for form validation.
 
+    Args:
+        message (str): Description of the validation failure.
+        field (str | None): Name of the field that failed validation.
+        value (Any): The invalid value (will be sanitized in logs).
+        details (dict[str, Any] | None): Additional validation context.
+        error_code (str | None): Machine-readable error code.
+
     Example:
         >>> raise ValidationError(
         ...     "Invalid email format",
@@ -125,15 +125,6 @@ class ValidationError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize validation error with field context.
-
-        Args:
-            message: Description of the validation failure.
-            field: Name of the field that failed validation.
-            value: The invalid value (will be sanitized in logs).
-            details: Additional validation context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if field:
             details["field"] = field
@@ -153,6 +144,13 @@ class ResourceNotFoundError(ProjectBaseError):
 
     Raised when a requested resource (entity, file, record) cannot be found.
 
+    Args:
+        message (str): Description of what was not found.
+        resource_type (str | None): Type of resource (e.g., "User", "Document").
+        resource_id (str | None): Identifier of the missing resource.
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
+
     Example:
         >>> raise ResourceNotFoundError(
         ...     "User not found",
@@ -170,15 +168,6 @@ class ResourceNotFoundError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize resource not found error.
-
-        Args:
-            message: Description of what was not found.
-            resource_type: Type of resource (e.g., "User", "Document").
-            resource_id: Identifier of the missing resource.
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if resource_type:
             details["resource_type"] = resource_type
@@ -192,6 +181,11 @@ class AuthenticationError(ProjectBaseError):
 
     Raised when authentication fails (invalid credentials, expired tokens, etc.).
 
+    Args:
+        message (str): Description of authentication failure.
+        details (dict[str, Any] | None): Additional context (avoid including sensitive data).
+        error_code (str | None): Machine-readable error code.
+
     Example:
         >>> raise AuthenticationError("Invalid or expired token")
     """
@@ -203,13 +197,6 @@ class AuthenticationError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize authentication error.
-
-        Args:
-            message: Description of authentication failure.
-            details: Additional context (avoid including sensitive data).
-            error_code: Machine-readable error code.
-        """
         super().__init__(
             message, details=details, error_code=error_code or "AUTH_FAILED"
         )
@@ -219,6 +206,13 @@ class AuthorizationError(ProjectBaseError):
     """Authorization/permission errors.
 
     Raised when a user lacks permission to perform an action.
+
+    Args:
+        message (str): Description of permission failure.
+        required_permission (str | None): The permission that was required.
+        resource (str | None): The resource access was denied to.
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
 
     Example:
         >>> raise AuthorizationError(
@@ -237,15 +231,6 @@ class AuthorizationError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize authorization error.
-
-        Args:
-            message: Description of permission failure.
-            required_permission: The permission that was required.
-            resource: The resource access was denied to.
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if required_permission:
             details["required_permission"] = required_permission
@@ -258,6 +243,13 @@ class ExternalServiceError(ProjectBaseError):
     """External service/dependency errors.
 
     Base class for errors from external services (APIs, databases, etc.).
+
+    Args:
+        message (str): Description of the service error.
+        service_name (str | None): Name of the external service.
+        status_code (int | None): HTTP status code if applicable.
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
 
     Example:
         >>> raise ExternalServiceError(
@@ -276,15 +268,6 @@ class ExternalServiceError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize external service error.
-
-        Args:
-            message: Description of the service error.
-            service_name: Name of the external service.
-            status_code: HTTP status code if applicable.
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if service_name:
             details["service_name"] = service_name
@@ -299,6 +282,14 @@ class APIError(ExternalServiceError):
     """External API errors.
 
     Raised when calls to external APIs fail.
+
+    Args:
+        message (str): Description of the API error.
+        service_name (str | None): Name of the external API.
+        status_code (int | None): HTTP status code from the API.
+        retry_after (int | None): Seconds to wait before retrying (for rate limits).
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
 
     Example:
         >>> raise APIError(
@@ -319,16 +310,6 @@ class APIError(ExternalServiceError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize API error.
-
-        Args:
-            message: Description of the API error.
-            service_name: Name of the external API.
-            status_code: HTTP status code from the API.
-            retry_after: Seconds to wait before retrying (for rate limits).
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if retry_after:
             details["retry_after"] = retry_after
@@ -345,6 +326,13 @@ class DatabaseError(ExternalServiceError):
     """Database operation errors.
 
     Raised when database operations fail (connection issues, constraint violations, etc.).
+
+    Args:
+        message (str): Description of the database error.
+        operation (str | None): The database operation that failed.
+        table (str | None): The table/collection involved.
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
 
     Example:
         >>> raise DatabaseError(
@@ -363,15 +351,6 @@ class DatabaseError(ExternalServiceError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize database error.
-
-        Args:
-            message: Description of the database error.
-            operation: The database operation that failed.
-            table: The table/collection involved.
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if operation:
             details["operation"] = operation
@@ -390,6 +369,13 @@ class BusinessLogicError(ProjectBaseError):
 
     Raised when operations violate business rules or domain constraints.
 
+    Args:
+        message (str): Description of the rule violation.
+        rule (str | None): Name of the business rule violated.
+        context (dict[str, Any] | None): Business context for the violation.
+        details (dict[str, Any] | None): Additional context.
+        error_code (str | None): Machine-readable error code.
+
     Example:
         >>> raise BusinessLogicError(
         ...     "Insufficient funds for transfer",
@@ -407,15 +393,6 @@ class BusinessLogicError(ProjectBaseError):
         details: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> None:
-        """Initialize business logic error.
-
-        Args:
-            message: Description of the rule violation.
-            rule: Name of the business rule violated.
-            context: Business context for the violation.
-            details: Additional context.
-            error_code: Machine-readable error code.
-        """
         details = details or {}
         if rule:
             details["rule"] = rule

--- a/src/fragrance_rater/llm/client.py
+++ b/src/fragrance_rater/llm/client.py
@@ -28,10 +28,10 @@ class LLMRatingResult:
     """Structured result returned by :class:`LLMRatingClient`.
 
     Attributes:
-        score: Integer rating from 1 (poor) to 10 (excellent).
-        reasoning: Human-readable explanation of the score.
-        model: Identifier of the LLM model that produced the rating.
-        notes: Optional list of perfumer-style tasting notes.
+        score (int): Integer rating from 1 (poor) to 10 (excellent).
+        reasoning (str): Human-readable explanation of the score.
+        model (str): Identifier of the LLM model that produced the rating.
+        notes (list[str]): Optional list of perfumer-style tasting notes.
     """
 
     score: int
@@ -63,14 +63,17 @@ class LLMRatingClient:
         """Score a fragrance using the configured LLM.
 
         Args:
-            name: Fragrance name.
-            brand: Fragrance house / brand, if known.
-            description: Free-text description of the scent.
-            notes: Optional list of top/heart/base notes.
+            name (str): Fragrance name.
+            brand (str | None): Fragrance house / brand, if known.
+            description (str): Free-text description of the scent.
+            notes (list[str] | None): Optional list of top/heart/base notes.
 
         Returns:
-            An :class:`LLMRatingResult` with the score, reasoning,
-            model name, and an echoed list of notes.
+            LLMRatingResult: Score, reasoning, model name, and echoed notes.
+
+        Raises:
+            RuntimeError: When TEST_MODE is disabled and no OpenRouter
+                integration is configured.
         """
         if _is_test_mode():
             return _fixture_response(name=name, brand=brand, notes=notes)

--- a/src/fragrance_rater/middleware/correlation.py
+++ b/src/fragrance_rater/middleware/correlation.py
@@ -75,7 +75,7 @@ def get_correlation_id() -> str | None:
     """Get the current request's correlation ID.
 
     Returns:
-        Correlation ID string or None if not in a request context.
+        str | None: Correlation ID string or None if not in a request context.
 
     Example:
         >>> from fragrance_rater.middleware.correlation import get_correlation_id
@@ -89,7 +89,7 @@ def get_request_id() -> str | None:
     """Get the current request's unique request ID.
 
     Returns:
-        Request ID string or None if not in a request context.
+        str | None: Request ID string or None if not in a request context.
     """
     return _request_id_ctx.get()
 
@@ -98,7 +98,7 @@ def get_trace_id() -> str | None:
     """Get the current request's trace ID for distributed tracing.
 
     Returns:
-        Trace ID string or None if not in a request context.
+        str | None: Trace ID string or None if not in a request context.
     """
     return _trace_id_ctx.get()
 
@@ -107,7 +107,7 @@ def get_span_id() -> str | None:
     """Get the current request's span ID.
 
     Returns:
-        Span ID string or None if not in a request context.
+        str | None: Span ID string or None if not in a request context.
     """
     return _span_id_ctx.get()
 
@@ -118,7 +118,7 @@ def set_correlation_id(correlation_id: str) -> None:
     Useful for background jobs or non-HTTP contexts.
 
     Args:
-        correlation_id: The correlation ID to set.
+        correlation_id (str): The correlation ID to set.
     """
     _correlation_id_ctx.set(correlation_id)
 
@@ -127,7 +127,7 @@ def generate_correlation_id() -> str:
     """Generate a new correlation ID.
 
     Returns:
-        A new UUID4 string suitable for use as a correlation ID.
+        str: A new UUID4 string suitable for use as a correlation ID.
     """
     return str(uuid.uuid4())
 
@@ -151,12 +151,12 @@ def correlation_context_processor(
         )
 
     Args:
-        _logger: The wrapped logger instance (unused).
-        _method_name: The name of the log method called (unused).
-        event_dict: The event dictionary to process.
+        _logger (WrappedLogger): The wrapped logger instance (unused).
+        _method_name (str): The name of the log method called (unused).
+        event_dict (EventDict): The event dictionary to process.
 
     Returns:
-        Updated event dictionary with correlation IDs.
+        EventDict: Updated event dictionary with correlation IDs.
     """
     correlation_id = _correlation_id_ctx.get()
     request_id = _request_id_ctx.get()
@@ -206,11 +206,12 @@ class CorrelationMiddleware(BaseHTTPMiddleware):
         """Process request with correlation ID handling.
 
         Args:
-            request: The incoming HTTP request.
-            call_next: The next middleware or route handler.
+            request (Request): The incoming HTTP request.
+            call_next (Callable[[Request], Awaitable[Response]]): The next middleware
+                or route handler.
 
         Returns:
-            The HTTP response with correlation headers added.
+            Response: The HTTP response with correlation headers added.
         """
         # Extract or generate correlation ID
         correlation_id = (
@@ -276,12 +277,12 @@ def configure_sentry_correlation() -> None:
         """Add correlation IDs to Sentry events.
 
         Args:
-            event: Sentry event dictionary to enrich with correlation tags.
-            _hint: Sentry-supplied event hint metadata (unused).
+            event (dict[str, Any]): Sentry event dictionary to enrich with correlation tags.
+            _hint (dict[str, Any]): Sentry-supplied event hint metadata (unused).
 
         Returns:
-            The same event dictionary, augmented with correlation tags
-            when any are present in the current request context.
+            dict[str, Any] | None: The same event dictionary, augmented with
+            correlation tags when any are present in the current request context.
         """
         correlation_id = _correlation_id_ctx.get()
         request_id = _request_id_ctx.get()

--- a/src/fragrance_rater/utils/logging.py
+++ b/src/fragrance_rater/utils/logging.py
@@ -42,13 +42,13 @@ def setup_logging(
     for the environment (JSON for production, rich console for development).
 
     Args:
-        level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        level (str): Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
             Defaults to INFO.
-        json_logs: If True, output JSON logs (production mode). If False,
+        json_logs (bool): If True, output JSON logs (production mode). If False,
             use rich console formatting (development mode). Defaults to False.
-        include_timestamp: Whether to include timestamps in log output.
+        include_timestamp (bool): Whether to include timestamps in log output.
             Defaults to True.
-        include_correlation: Whether to include correlation IDs from request
+        include_correlation (bool): Whether to include correlation IDs from request
             context in log output. Defaults to True. Requires API framework.
 
     Example:
@@ -139,15 +139,10 @@ def get_logger(name: str) -> BoundLogger:
     typically be called with __name__ to create module-specific loggers.
 
     Args:
-        name: Logger name (typically __name__ of the module).
+        name (str): Logger name (typically __name__ of the module).
 
     Returns:
-        Configured structlog logger instance with methods like:
-        - logger.info()
-        - logger.debug()
-        - logger.warning()
-        - logger.error()
-        - logger.exception()
+        BoundLogger: Configured structlog logger instance.
 
     Example:
         >>> logger = get_logger(__name__)
@@ -174,11 +169,11 @@ def log_performance(
     duration, success status, and additional context.
 
     Args:
-        logger: Structlog logger instance from get_logger().
-        operation: Name of the operation being timed.
-        duration_ms: Duration in milliseconds.
-        success: Whether the operation succeeded. Defaults to True.
-        **context: Additional context key-value pairs to include in the log.
+        logger (BoundLogger): Structlog logger instance from get_logger().
+        operation (str): Name of the operation being timed.
+        duration_ms (float): Duration in milliseconds.
+        success (bool): Whether the operation succeeded. Defaults to True.
+        **context (object): Additional context key-value pairs to include in the log.
 
     Example:
         >>> logger = get_logger(__name__)

--- a/uv.lock
+++ b/uv.lock
@@ -791,15 +791,6 @@ validation = [
 ]
 
 [[package]]
-name = "darglint"
-version = "1.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/2c/86e8549e349388c18ca8a4ff8661bb5347da550f598656d32a98eaaf91cc/darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da", size = 74435, upload-time = "2021-10-18T03:40:37.283Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/28/85d1e0396d64422c5218d68e5cdcc53153aa8a2c83c7dbc3ee1502adf3a1/darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d", size = 120767, upload-time = "2021-10-18T03:40:35.034Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -866,6 +857,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docstring-parser-fork"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/bf/27f9cab2f0cd1d17a4420572088bbc19f36d726fbcf165edf226a8926dbc/docstring_parser_fork-0.0.14.tar.gz", hash = "sha256:a2743a63d8d36c09650594f7b4ab5b2758fee8629dcf794d1b221b23179baa5c", size = 34551, upload-time = "2025-09-07T17:27:38.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/50/98b146aea0f1cd7531d25f12bea69fa9ce8d1662124f93fb30dc4511b65e/docstring_parser_fork-0.0.14-py3-none-any.whl", hash = "sha256:4c544f234ef2cc2749a3df32b70c437d77888b1099143a1ad5454452c574b9af", size = 43063, upload-time = "2025-09-07T17:27:37.012Z" },
 ]
 
 [[package]]
@@ -969,7 +969,6 @@ caching = [
 dev = [
     { name = "bandit" },
     { name = "basedpyright" },
-    { name = "darglint" },
     { name = "google-api-core" },
     { name = "google-auth" },
     { name = "griffe-pydantic" },
@@ -989,6 +988,7 @@ dev = [
     { name = "nox-uv" },
     { name = "pip-audit" },
     { name = "pre-commit" },
+    { name = "pydoclint" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1021,7 +1021,6 @@ requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.18.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "cyclonedx-bom", marker = "extra == 'supply-chain'", specifier = ">=4.6.0" },
-    { name = "darglint", marker = "extra == 'dev'", specifier = ">=1.8.1" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.120.1" },
     { name = "google-api-core", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.0.0" },
@@ -1047,6 +1046,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.3.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pydoclint", marker = "extra == 'dev'", specifier = ">=0.8.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
@@ -3258,6 +3258,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pydoclint"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "docstring-parser-fork" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/c9/357fb4af8ca78b97b6642e18e8b692a7073bf118709e559ec6f8a893774d/pydoclint-0.8.4.tar.gz", hash = "sha256:5eb5d8ae3d17bba9a1e4ac3ccdedf46152d45e60528895c26712cf7337b2a054", size = 195295, upload-time = "2026-05-16T20:31:37.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f9/f15c95d6b200167cb22c5eca5eecfa9d28a8ee3f74095f1cd2345c71f2f9/pydoclint-0.8.4-py3-none-any.whl", hash = "sha256:5e0f94f785d0e902faacebb117aadf84d6e30c5f781e0fdd0ee03c3b80ea2098", size = 82023, upload-time = "2026-05-16T20:31:36.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrates docstring argument validation from the archived `darglint` to `pydoclint` per the updated standards manifest (TOOL-007 pydoclint present, PC-006 pydoclint hook, TOOL-013 darglint absent)
- Posture: google style, type hints required in both docstring args and signature, lenient on Returns/Yields sections, raises checking enabled
- Extends pydoclint exclude to cover `docs/` planning scaffolds (consistent with existing tool excludes)
- Fixes all 40+ DOC violations (DOC105/109/110/203/301/601-605) across 8 source files; no annotations were invented -- all types copied directly from existing signature annotations

## Changes

**Toolchain (commit 1):**
- `pyproject.toml`: swap `darglint>=1.8.1` for `pydoclint>=0.8.4`; replace `[tool.darglint]` with `[tool.pydoclint]`; remove darglint from `ci: skip` list
- `.pre-commit-config.yaml`: replace local darglint hook with pinned pydoclint 0.8.4 hook (`88d83c94`); extend exclude to cover `docs/`
- `uv.lock`: darglint removed, pydoclint + docstring-parser-fork added

**Docstring fixes (commit 2):**
- `api/fragrances.py`, `api/health.py`, `api/ratings.py`: arg and return types added
- `core/config.py`: `model_config` given explicit type annotation; Attributes section updated
- `core/exceptions.py`: `__init__` docstrings consolidated into class docstrings (DOC301); Args typed throughout
- `llm/client.py`: `LLMRatingResult` attrs typed; `rate()` args/return typed; `RuntimeError` Raises section added
- `middleware/correlation.py`: all functions typed
- `utils/logging.py`: all functions typed

## Test plan

- [ ] `uv run pydoclint src/` exits clean (no violations)
- [ ] `pre-commit run pydoclint --all-files` passes
- [ ] `pre-commit run --all-files` shows no regressions on pydoclint-related hooks
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)