### PR TITLE
fix(renovate): add npm and pip_requirements to enabledManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -211,6 +211,8 @@
   ],
   "enabledManagers": [
     "pep621",
-    "github-actions"
+    "github-actions",
+    "npm",
+    "pip_requirements"
   ]
 }


### PR DESCRIPTION
## Summary

The repo's `renovate.json` set `enabledManagers` to `["pep621", "github-actions"]`, but the repository also contains manifests for two additional ecosystems that Renovate was therefore ignoring:

- `frontend/package.json` and `docs/planning/frontend/package.json` (npm)
- `docs/planning/backend/requirements.txt` (pip_requirements)

This adds `npm` and `pip_requirements` to `enabledManagers` so Renovate tracks every ecosystem present in the repo. Existing entries (`pep621`, `github-actions`) are preserved.

## Verification

- `renovate.json` validated as well-formed JSON.
- Manifest presence confirmed via `git ls-files`.
- pre-commit (check json, em-dash guard, etc.) passes on the changed file.

Generated with [Claude Code](https://claude.com/claude-code)