### PR TITLE
chore(deps): add detection-only dependabot.yml (Renovate sole PR-opener)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+# Detection-only: Renovate is the sole PR-opener. open-pull-requests-limit: 0
+# suppresses Dependabot version PRs. Dependabot alerts (a repo setting) remain
+# the multi-ecosystem detection ledger. Refs: standards CI-021 (amended), CI-074.
+updates:
+  - package-ecosystem: "pip"            # Python: pyproject.toml / uv.lock at root
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions" # .github/workflows/ present
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "npm"            # frontend/package.json
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "docker"         # root Dockerfile
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "docker"         # frontend/Dockerfile
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a new `.github/dependabot.yml` in detection-only mode (Stage 4 Cat A).

`open-pull-requests-limit: 0` on every ecosystem suppresses Dependabot version PRs so Renovate remains the sole PR-opener, while Dependabot **alerts** (a separate repo setting) stay on as the multi-ecosystem detection ledger. Refs: standards CI-021 (amended), CI-074.

Ecosystems included (verified against manifests in the clone):
- `pip` at `/` (pyproject.toml + uv.lock)
- `github-actions` at `/` (.github/workflows/)
- `npm` at `/frontend` (frontend/package.json)
- `docker` at `/` (root Dockerfile)
- `docker` at `/frontend` (frontend/Dockerfile)

Note: `docs/planning/` Dockerfile/package.json are documentation scaffolding, not real build targets, so they are excluded.